### PR TITLE
[FEAT] 커뮤니티 질문 - 카테고리 및 제품 타입 선택 추가

### DIFF
--- a/client/src/api/profile.js
+++ b/client/src/api/profile.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const fetchProfile = userId => axios.post('/api/profile', { userId });
+const fetchProfile = () => axios.post('/api/profile');
 
 const editProfile = userInfo => axios.post('/api/profile/edit', { userInfo });
 

--- a/client/src/components/common/selectProduct/SelectProduct.jsx
+++ b/client/src/components/common/selectProduct/SelectProduct.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { Container, Radio } from '@mantine/core';
-import { ipadProductTypes, iphoneProductTypes, macbookProductTypes } from '../../../constants/productList';
 import SelectProductAccordion from './SelectProductAccordion';
 
 const Wrapper = styled(Container)`
@@ -29,26 +28,14 @@ const Wrapper = styled(Container)`
  * onChange: (e) => void
  * }} props
  */
-const SelectProduct = ({ selectedProductType, onChange }) => {
-  const productCategoryList = [
-    { categoryType: 'iPhone', productTypes: iphoneProductTypes },
-    { categoryType: 'iPad', productTypes: ipadProductTypes },
-    { categoryType: 'Macbook', productTypes: macbookProductTypes },
-  ];
-
-  return (
-    <Container w="100%">
-      <Wrapper>
-        <Radio.Group value={selectedProductType} onChange={onChange}>
-          <SelectProductAccordion
-            selectedProductType={selectedProductType}
-            productCategoryList={productCategoryList}
-            multiple={true}
-          />
-        </Radio.Group>
-      </Wrapper>
-    </Container>
-  );
-};
+const SelectProduct = ({ selectedProductType, onChange }) => (
+  <Container w="100%">
+    <Wrapper>
+      <Radio.Group value={selectedProductType} onChange={onChange}>
+        <SelectProductAccordion selectedProductType={selectedProductType} multiple={true} />
+      </Radio.Group>
+    </Wrapper>
+  </Container>
+);
 
 export default SelectProduct;

--- a/client/src/components/common/selectProduct/SelectProductAccordion.jsx
+++ b/client/src/components/common/selectProduct/SelectProductAccordion.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Accordion, Title } from '@mantine/core';
 import SelectProductAccordionPanel from './SelectProductAccordionPanel';
+import { ipadProductTypes, iphoneProductTypes, macbookProductTypes } from '../../../constants/productList';
 
 /**
  * @param {{
@@ -11,19 +12,31 @@ import SelectProductAccordionPanel from './SelectProductAccordionPanel';
  * multiple?: boolean
  * }} props
  */
-const SelectProductAccordion = ({ selectedProductType, productCategoryList, multiple = false }) => (
-  <Accordion variant="contained" multiple={multiple}>
-    {productCategoryList.map(({ categoryType, productTypes }) => (
-      <Accordion.Item value={categoryType} key={categoryType}>
-        <Accordion.Control>
-          <Title size="lg" c={'var(--font-color)'}>
-            {categoryType}
-          </Title>
-        </Accordion.Control>
-        <SelectProductAccordionPanel productTypes={productTypes} selectedProductType={selectedProductType} />
-      </Accordion.Item>
-    ))}
-  </Accordion>
-);
+const SelectProductAccordion = ({ selectedProductType, onSelectProduct, multiple = false }) => {
+  const productCategoryList = [
+    { categoryType: 'iPhone', productTypes: iphoneProductTypes },
+    { categoryType: 'iPad', productTypes: ipadProductTypes },
+    { categoryType: 'Macbook', productTypes: macbookProductTypes },
+  ];
+
+  return (
+    <Accordion variant="contained" multiple={multiple}>
+      {productCategoryList.map(({ categoryType, productTypes }) => (
+        <Accordion.Item value={categoryType} key={categoryType}>
+          <Accordion.Control>
+            <Title size="lg" c={'var(--font-color)'}>
+              {categoryType}
+            </Title>
+          </Accordion.Control>
+          <SelectProductAccordionPanel
+            productTypes={productTypes}
+            selectedProductType={selectedProductType}
+            onSelectProduct={onSelectProduct}
+          />
+        </Accordion.Item>
+      ))}
+    </Accordion>
+  );
+};
 
 export default SelectProductAccordion;

--- a/client/src/components/common/selectProduct/SelectProductAccordionPanel.jsx
+++ b/client/src/components/common/selectProduct/SelectProductAccordionPanel.jsx
@@ -55,7 +55,7 @@ const ItemImage = styled(Image)`
   }
 `;
 
-const SelectProductAccordionPanel = ({ productTypes, selectedProductType }) => (
+const SelectProductAccordionPanel = ({ productTypes, selectedProductType, onSelectProduct }) => (
   <Accordion.Panel>
     <Flex ml="10px" gap="10px" wrap="wrap">
       {Object.entries(productTypes).map(([productType, productName]) => (
@@ -63,6 +63,9 @@ const SelectProductAccordionPanel = ({ productTypes, selectedProductType }) => (
           <RadioInput
             checked={selectedProductType === productType}
             value={productType}
+            onClick={() => {
+              if (onSelectProduct) onSelectProduct(productType);
+            }}
             label={
               <ItemCard>
                 <ItemImage src={productThumbnail[productType]} alt={`product-${productType}`} />

--- a/client/src/components/community/CategoryRadio.jsx
+++ b/client/src/components/community/CategoryRadio.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import { Radio, Flex, Text, Group, Image } from '@mantine/core';
-import { useController } from 'react-hook-form';
+import { Radio, Flex, Text, Image, Container } from '@mantine/core';
 import categoryList from '../../constants/categoryList';
 
 const RadioInput = styled(Radio)`
@@ -13,48 +12,54 @@ const RadioInput = styled(Radio)`
   label {
     padding: 0;
   }
+
+  .mantine-Radio-labelWrapper {
+    width: 100%;
+  }
 `;
 
-const RadioLabel = styled(Group)`
+const RadioLabel = styled(Container)`
   --color: ${({ checked }) => `var(${checked ? '--hover-font-color' : '--font-color'})`};
   display: flex;
-  width: 280px;
-  gap: 12px;
+  width: 100%;
   padding: 8px;
   font-size: 20px;
   align-items: center;
   color: var(--color);
-  border: 2px solid var(--color);
+  border: 1px solid var(--color);
   border-radius: 10px;
 
   img {
-    height: 75px;
+    max-width: 40px;
+    max-height: 40px;
+    width: content-fit;
+    object-fit: scale-down !important;
+  }
+
+  .mantine-Image-root {
+    width: fit-content !important;
   }
 `;
 
-const CategoryRadio = ({ control }) => {
-  const {
-    field: { value, onChange },
-  } = useController({ control, name: 'category' });
-
-  return (
-    <Radio.Group value={value} onChange={onChange}>
-      <Flex gap="20px">
-        {categoryList.map(({ imgPath, category }) => (
-          <RadioInput
-            key={category}
-            value={category}
-            label={
-              <RadioLabel checked={value === category}>
-                <Image src={imgPath} alt="" />
-                <Text>{category}</Text>
-              </RadioLabel>
-            }
-          />
-        ))}
-      </Flex>
-    </Radio.Group>
-  );
-};
+const CategoryRadio = ({ value, onChange, onResetProduct }) => (
+  <Radio.Group value={value} onChange={onChange} px="10px">
+    <Flex gap="2%">
+      {categoryList.map(({ imgPath, category }) => (
+        <RadioInput
+          key={category}
+          w="32%"
+          value={category}
+          onClick={onResetProduct}
+          label={
+            <RadioLabel checked={value === category}>
+              <Image src={imgPath} alt="" />
+              <Text ml="lg">{category}</Text>
+            </RadioLabel>
+          }
+        />
+      ))}
+    </Flex>
+  </Radio.Group>
+);
 
 export default CategoryRadio;

--- a/client/src/components/community/MyProductListPanel.jsx
+++ b/client/src/components/community/MyProductListPanel.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { Accordion, Flex, Image, Radio, Text } from '@mantine/core';
+import styled from '@emotion/styled';
+import productThumbnail from '../../constants/productThumbnail';
+import { productTypes } from '../../constants/productList';
+
+const RadioInput = styled(Radio)`
+  --color: ${({ checked }) => `var(${checked ? '--hover-font-color' : '--opacity-border-color'})`};
+
+  flex-basis: calc(25% - 10px);
+  width: 100%;
+  height: 100%;
+  background: var(--opacity-bg-color);
+  color: var(--color);
+  border: 2px solid var(--color);
+  border-radius: 10px;
+  /* cursor: pointer; */
+
+  :hover {
+    border: 2px solid #0071e285;
+  }
+
+  input,
+  svg {
+    display: none;
+  }
+  label {
+    padding: 0;
+    cursor: pointer;
+  }
+
+  .mantine-Radio-labelWrapper {
+    width: 100%;
+  }
+
+  .mantine-Accordion-item:last-child {
+    border: none;
+  }
+`;
+
+const ItemCard = styled(Flex)`
+  align-items: center;
+  width: 100%;
+  height: 70px;
+  padding: 5px 12px;
+`;
+
+const ItemImage = styled(Image)`
+  max-width: 40px;
+  max-height: 40px;
+
+  img {
+    max-width: 40px;
+    max-height: 40px;
+    object-fit: scale-down !important;
+  }
+`;
+
+const MyProductListPanel = ({ products, selectedProductType, onSelectProduct }) => (
+  <Accordion.Panel>
+    <Flex ml="10px" gap="10px" wrap="wrap">
+      {products.map(({ type: productType }, index) => (
+        <RadioInput
+          key={index}
+          checked={selectedProductType === productType}
+          value={productType}
+          onClick={() => {
+            onSelectProduct(productType);
+          }}
+          label={
+            <ItemCard>
+              <ItemImage src={productThumbnail[productType]} alt={`product-${productType}`} />
+              <Text size="md" c={'var(--font-color)'} w="100%">
+                {productTypes[productType]}
+              </Text>
+            </ItemCard>
+          }
+        />
+      ))}
+    </Flex>
+  </Accordion.Panel>
+);
+
+export default MyProductListPanel;

--- a/client/src/components/community/SelectProductRadio.jsx
+++ b/client/src/components/community/SelectProductRadio.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import styled from '@emotion/styled';
+import { Accordion, Container, Radio, Title } from '@mantine/core';
+import { profileQuery } from '../../pages/Profile';
+import MyProductListPanel from './MyProductListPanel';
+import { SelectProductAccordion } from '../common';
+
+const PanelContainer = styled(Container)`
+  width: 100%;
+  color: var(--font-color);
+  padding: 10px;
+  margin-top: 30px;
+
+  .mantine-Accordion-item,
+  .mantine-Accordion-itemTitle,
+  .mantine-Accordion-control {
+    background: none;
+    border-color: var(--font-color);
+  }
+
+  .mantine-Accordion-chevron {
+    color: var(--font-color);
+  }
+`;
+
+const SelectProductRadio = ({ value, onChange, onSelectProduct }) => {
+  const { data: userInfo } = useQuery({ ...profileQuery(), suspense: false });
+
+  return (
+    <PanelContainer>
+      <Radio.Group value={value} onChange={onChange}>
+        <Accordion variant="default">
+          <Accordion.Item value="나의 기기 목록">
+            <Accordion.Control>
+              <Title size="lg" c={'var(--font-color)'}>
+                나의 기기 목록
+              </Title>
+            </Accordion.Control>
+            <MyProductListPanel
+              products={userInfo?.products ?? []}
+              selectedProductType={value}
+              onSelectProduct={onSelectProduct}
+            />
+          </Accordion.Item>
+
+          <Accordion.Item value="제품 목록">
+            <Accordion.Control>
+              <Title size="lg" c={'var(--font-color)'}>
+                제품 목록
+              </Title>
+            </Accordion.Control>
+            <Accordion.Panel>
+              <SelectProductAccordion selectedProductType={value} onSelectProduct={onSelectProduct} />
+            </Accordion.Panel>
+          </Accordion.Item>
+        </Accordion>
+      </Radio.Group>
+    </PanelContainer>
+  );
+};
+
+export default SelectProductRadio;

--- a/client/src/components/community/SelectedCategoryAndProductType.jsx
+++ b/client/src/components/community/SelectedCategoryAndProductType.jsx
@@ -1,0 +1,45 @@
+import styled from '@emotion/styled';
+import { Badge, Container, Flex, Text } from '@mantine/core';
+import React from 'react';
+import { productTypes } from '../../constants/productList';
+
+const SelectedGroup = styled(Flex)`
+  background-color: var(--opacity-bg-color);
+  border: 1px solid var(--opacity-border-color);
+  padding: 30px 40px;
+  border-radius: 10px;
+  justify-content: center;
+`;
+
+const SelectedCategoryAndProductType = ({ categoryType, selectedProductType }) => (
+  <SelectedGroup>
+    {categoryType ? (
+      <Container w="100%">
+        <Flex align="flex-end" w="100%">
+          <Text size="lg" mr="sm" c="var(--font-color)">
+            {'선택 카테고리 : '}
+          </Text>
+          <Badge variant="outline" size="lg">
+            {categoryType}
+          </Badge>
+        </Flex>
+        {selectedProductType && (
+          <Flex align="flex-end" w="100%" mt="10px">
+            <Text size="lg" mr="sm" c="var(--font-color)">
+              {'선택 제품 타입 : '}
+            </Text>
+            <Badge variant="outline" size="lg">
+              {productTypes[selectedProductType]}
+            </Badge>
+          </Flex>
+        )}
+      </Container>
+    ) : (
+      <Text size="lg" mr="sm" c="var(--font-color)">
+        {'질문에 해당하는 카테고리 또는 상품을 선택해주세요.'}
+      </Text>
+    )}
+  </SelectedGroup>
+);
+
+export default SelectedCategoryAndProductType;

--- a/client/src/components/community/index.js
+++ b/client/src/components/community/index.js
@@ -10,6 +10,9 @@ export { default as CommunitySkeleton } from './CommunitySkeleton';
 
 export { default as TextEditor } from './TextEditor';
 export { default as CategoryRadio } from './CategoryRadio';
+export { default as SelectProductRadio } from './SelectProductRadio';
+export { default as SelectedCategoryAndProductType } from './SelectedCategoryAndProductType';
+export { default as MyProductListPanel } from './MyProductListPanel';
 export { default as QuestionForm } from './QuestionForm';
 
 export { default as CheckedCircleIcon } from './CheckedCircleIcon';

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -11,10 +11,10 @@ const staleTime = 3000;
 /**
  * query
  */
-const profileQuery = userId => ({
-  queryKey: ['profile', userId],
+const profileQuery = () => ({
+  queryKey: ['profile'],
   queryFn: async () => {
-    const { data } = await fetchProfile(userId);
+    const { data } = await fetchProfile();
     return data;
   },
   staleTime,

--- a/client/src/pages/RegisterProduct.jsx
+++ b/client/src/pages/RegisterProduct.jsx
@@ -59,7 +59,7 @@ const RegisterProduct = () => {
 
         <SelectedProduct selectedProductType={selectedProductType} />
 
-        <Container align="center">
+        <Container align="center" mb="30px">
           <Button type="submit" size="lg" w="100%" disabled={!isDirty && !isValid} loading={isSubmitting}>
             등록하기
           </Button>

--- a/server/mock-data/posts.js
+++ b/server/mock-data/posts.js
@@ -10,6 +10,7 @@ const comments = require('./comments');
 		updateAt: date,
 		comments: array[],
 		category: string,
+		productType: string,
 		completed: boolean,
 	},
  */
@@ -35,6 +36,7 @@ let posts = [
 		createAt: new Date('2022-11-01'),
 		updateAt: new Date(),
 		category: 'iPhone',
+		productType: '',
 		completed: false,
 	},
 
@@ -46,6 +48,7 @@ let posts = [
 		createAt: new Date('2022-12-01'),
 		updateAt: new Date(),
 		category: 'iPhone',
+		productType: '',
 		completed: false,
 	},
 	{
@@ -56,6 +59,7 @@ let posts = [
 		createAt: new Date('2022-12-15'),
 		updateAt: new Date(),
 		category: 'iphone',
+		productType: '',
 		completed: false,
 	},
 	{
@@ -66,6 +70,7 @@ let posts = [
 		createAt: new Date('2022-12-24'),
 		updateAt: new Date(),
 		category: 'iPhone',
+		productType: '',
 		completed: true,
 	},
 	{
@@ -77,6 +82,7 @@ let posts = [
 		createAt: new Date('2022-12-31'),
 		updateAt: new Date(),
 		category: 'iPhone',
+		productType: '',
 		completed: false,
 	},
 	{
@@ -87,6 +93,7 @@ let posts = [
 		createAt: new Date('2023-01-01'),
 		updateAt: new Date(),
 		category: 'Mac',
+		productType: '',
 		completed: false,
 	},
 	{
@@ -97,6 +104,7 @@ let posts = [
 		createAt: new Date('2023-01-31'),
 		updateAt: new Date(),
 		category: 'Mac',
+		productType: '',
 		completed: false,
 	},
 	{
@@ -107,6 +115,7 @@ let posts = [
 		createAt: new Date('2023-02-01'),
 		updateAt: new Date(),
 		category: 'Mac',
+		productType: '',
 		completed: true,
 	},
 	{
@@ -117,6 +126,7 @@ let posts = [
 		createAt: new Date('2023-02-28'),
 		updateAt: new Date(),
 		category: 'Mac',
+		productType: '',
 		completed: false,
 	},
 	{
@@ -127,6 +137,7 @@ let posts = [
 		createAt: new Date('2023-03-01'),
 		updateAt: new Date(),
 		category: 'Mac',
+		productType: '',
 		completed: false,
 	},
 ];

--- a/server/router/profile.js
+++ b/server/router/profile.js
@@ -7,39 +7,49 @@ const TOKEN = 'accessToken';
 
 // 사용자 프로필
 router.post('/', (req, res) => {
-	const { userId } = req.body;
+	try {
+		const accessToken = req.cookies.accessToken;
+		const decoded = jwt.verify(accessToken, process.env.JWT_SECRET_KEY);
 
-	const user = users.findUserByEmail(userId);
+		const { email: userId } = users.findUserByEmail(decoded.email);
 
-	if (!user)
-		return res.status(401).send({ error: '해당 사용자가 존재하지 않습니다.' });
+		const user = users.findUserByEmail(userId);
 
-	const {
-		nickName,
-		firstName,
-		lastName,
-		country,
-		phoneNumber,
-		products,
-		point,
-		level,
-		avatarId,
-		aboutMe,
-		birthDate,
-	} = user;
+		if (!user)
+			return res
+				.status(401)
+				.send({ error: '해당 사용자가 존재하지 않습니다.' });
 
-	res.send({
-		nickName,
-		name: firstName + lastName,
-		country,
-		phoneNumber,
-		products,
-		point,
-		level,
-		avatarId,
-		aboutMe,
-		birthDate,
-	});
+		const {
+			nickName,
+			firstName,
+			lastName,
+			country,
+			phoneNumber,
+			products,
+			point,
+			level,
+			avatarId,
+			aboutMe,
+			birthDate,
+		} = user;
+
+		res.send({
+			nickName,
+			name: firstName + lastName,
+			country,
+			phoneNumber,
+			products,
+			point,
+			level,
+			avatarId,
+			aboutMe,
+			birthDate,
+		});
+	} catch (e) {
+		console.error('😱 사용자 인증 실패..', e);
+		res.status(401).send({ auth: 'fail' });
+	}
 });
 
 // 프로필 수정


### PR DESCRIPTION
### Change
---
**profile**
- api - fetchProfile 수정 (userId 제거)
- Profile - profileQuery 수정 (userId 제거)
- server - 프로필 데이터 요청 수정 (userId - 액세스 토큰으로 확인)

**SelectProduct**
- SelectProduct 컴포넌트 수정 
- SelectProductAccordion 컴포넌트 수정 - onSelectProduct 추가
- SelectProductAccordionPanel 컴포넌트 수정 - onSelectProduct 추가

**QuestionForm**
- SelectProductRadio 컴포넌트 (제품 타입 선택) 추가 
- MyProductListPanel 컴포넌트 (내가 가진 기기목록에서 선택) 추가
- CategoryRadio 컴포넌트 - 스타일 수정 및 onResetProduct 추가
- SelectedCategoryAndProductType 컴포넌트 (선택한 카테고리 및 제품 타입) 추가

**mock-data**
- posts - productType 추가
