### PR TITLE
[FEAT] : productType 데이터 추가로 Badge UI 추가 및 캐시된 데이터 fetch 방법 수정

### DIFF
--- a/client/src/api/posts.js
+++ b/client/src/api/posts.js
@@ -6,6 +6,6 @@ const getSearchedPosts = ({ keyword = '', category }) =>
 const getPostsByCategory = ({ param: category, pageParam }) =>
   axios.get(`/api/posts?category=${category}&page=${pageParam}`);
 
-const getMyPosts = userId => axios.post('/api/posts/me', { userId });
+const getMyPosts = () => axios.get('/api/posts/me');
 
 export { getSearchedPosts, getPostsByCategory, getMyPosts };

--- a/client/src/components/community/Comment.jsx
+++ b/client/src/components/community/Comment.jsx
@@ -63,8 +63,15 @@ const UsefulBadge = styled(Group)`
   font-weight: 600;
 `;
 
-const Comment = ({ comment, isAuthor, editMutate, removeMutate }) => {
-  const { id, avatarId, certified, content, createAt, level, nickName, point, useful } = comment;
+const Comment = ({
+  comment,
+  isAuthor,
+  isPostAuthorAndLoginUserSame,
+  oneOfCommentsIsUseful,
+  editMutate,
+  removeMutate,
+}) => {
+  const { id, avatarId, certified, content, createAt, level, nickName, useful } = comment;
 
   const [commentEditable, setCommentEditable] = React.useState(false);
 
@@ -95,21 +102,18 @@ const Comment = ({ comment, isAuthor, editMutate, removeMutate }) => {
           <ProfileAvatar avatarId={avatarId} />
           <Flex direction="column" w="100%">
             <Flex display="flex" gap="10px">
-              <Text mt="-3px" ml="2px" fz="21px" fw="500" c="var(--font-color)">
-                {nickName}
-              </Text>
-              <Flex gap="8px" align="center" mb="1rem">
-                <Badge variant="outline" size="lg" fz="14px">
-                  레벨 {level}
-                </Badge>
-                <Badge variant="outline" size="lg" fz="14px">
-                  포인트 {point}
+              <Flex gap="10px" align="center">
+                <Text mt="-3px" ml="2px" fz="21px" fw="500" c="var(--font-color)">
+                  {nickName}
+                </Text>
+                <Badge variant="outline" size="sm" fz="14px" radius="xl" color="dark">
+                  L{level}
                 </Badge>
               </Flex>
 
               <Flex ml="auto" gap="10px">
-                {isAuthor ? (
-                  <UsefulCommentChip useful={useful} commentId={id} />
+                {isPostAuthorAndLoginUserSame ? (
+                  <UsefulCommentChip useful={useful} commentId={id} oneOfCommentsIsUseful={oneOfCommentsIsUseful} />
                 ) : (
                   <UsefulBadge>
                     <AiFillCheckCircle pos="absolute" top="0" size="16" />
@@ -117,17 +121,19 @@ const Comment = ({ comment, isAuthor, editMutate, removeMutate }) => {
                   </UsefulBadge>
                 )}
 
-                <Button
-                  onClick={() => {
-                    setCommentEditable(!commentEditable);
-                    editor.commands.focus('end');
-                  }}
-                  mb="4px"
-                  h="32px"
-                  color={commentEditable ? 'red' : 'blue'}
-                  radius="xl">
-                  {commentEditable ? '편집 취소' : '답글 편집'}
-                </Button>
+                {isAuthor && (
+                  <Button
+                    onClick={() => {
+                      setCommentEditable(!commentEditable);
+                      editor.commands.focus('end');
+                    }}
+                    mb="4px"
+                    h="32px"
+                    color={commentEditable ? 'red' : 'blue'}
+                    radius="xl">
+                    {commentEditable ? '편집 취소' : '답글 편집'}
+                  </Button>
+                )}
               </Flex>
             </Flex>
             <Text mb="10px" c="grey">

--- a/client/src/components/community/Comments.jsx
+++ b/client/src/components/community/Comments.jsx
@@ -36,7 +36,7 @@ const CommentList = styled(List)`
   min-width: 720px;
 `;
 
-const Comments = () => {
+const Comments = ({ postAuthor }) => {
   const { email, nickName, avatarId } = useRecoilValue(userState);
   const [textEditorContent, setTextEditorContent] = React.useState('');
 
@@ -68,6 +68,9 @@ const Comments = () => {
     },
   });
 
+  const appleRecommendComment = data?.comments.filter(({ certified }) => certified);
+  const filteredComments = data?.comments.filter(({ certified }) => !certified);
+
   return (
     <CommentsContainer>
       <CommentsHeader>
@@ -92,8 +95,22 @@ const Comments = () => {
           <FaLocationArrow size="16" />
         </Button>
       </CommentsHeader>
+      <CommentList>
+        {appleRecommendComment?.map(comment => (
+          <Comment
+            key={`${comment.id}_${comment.content}`}
+            comment={comment}
+            isAuthor={email === comment.author}
+            isPostAuthorAndLoginUserSame={email === postAuthor}
+            oneOfCommentsIsUseful={data?.comments?.some(({ useful }) => useful)}
+            editMutate={edit}
+            removeMutate={remove}
+          />
+        ))}
+      </CommentList>
+      <Divider mt="2rem" variant="dashed" />
       <Container miw="990px" my="20px" ref={targetRef}>
-        <Title m="3rem 0 2rem" ta="center" fz="2rem">
+        <Title m="5rem 0 2rem" ta="center" fz="2rem">
           💿 궁금한 점이 있다면 의견을 남겨주세요.
         </Title>
         <TextEditor editor={editor} />
@@ -128,13 +145,15 @@ const Comments = () => {
           </Button>
         </Flex>
       </Container>
-      <Divider mb="2rem" variant="dashed" />
+      <Divider mb="5rem" variant="dashed" />
       <CommentList>
-        {data?.comments.map(comment => (
+        {filteredComments?.map(comment => (
           <Comment
             key={`${comment.id}_${comment.content}`}
             comment={comment}
             isAuthor={email === comment.author}
+            isPostAuthorAndLoginUserSame={email === postAuthor}
+            oneOfCommentsIsUseful={data?.comments.some(({ useful }) => useful)}
             editMutate={edit}
             removeMutate={remove}
           />

--- a/client/src/components/community/CommunityMyPosts.jsx
+++ b/client/src/components/community/CommunityMyPosts.jsx
@@ -1,27 +1,25 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import Recoil from 'recoil';
 import { useQuery } from '@tanstack/react-query';
-import { Chip, Flex, Group, List } from '@mantine/core';
-import userState from '../../recoil/atoms/userState';
-import { communityMeQuery } from '../../pages/CommunityMe';
+import { Chip, Flex, Group, List, Text } from '@mantine/core';
 import { EmptyPostIndicator, PostItem } from '.';
+import { communityMeQuery } from '../../pages/CommunityMe';
 
 const MyPosts = styled(List)`
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  margin-top: 3rem;
+  margin-top: 2rem;
 `;
 
 const CommunityMyPosts = () => {
-  const loginUser = Recoil.useRecoilValue(userState);
-  // todo : loader 관련 useLoaderData hook 사용 예정
-  const { data } = useQuery(communityMeQuery(loginUser.email));
+  const { data } = useQuery(communityMeQuery());
   const [currentFilter, setCurrentFilter] = React.useState('recent');
 
   const filteredPosts = [...data.posts].sort((a, b) =>
-    currentFilter === 'recent' ? new Date(b.createAt) - new Date(a.createAt) : new Date(a.createAt - b.createAt)
+    currentFilter === 'recent'
+      ? new Date(b.createAt) - new Date(a.createAt)
+      : new Date(a.createAt) - new Date(b.createAt)
   );
 
   return (
@@ -30,9 +28,12 @@ const CommunityMyPosts = () => {
         <EmptyPostIndicator />
       ) : (
         <>
-          <Flex justify="flex-end">
+          <Flex justify="end" pos="relative">
+            <Text pos="absolute" top="-6.3rem" fz="5rem" fw="600" color="var(--font-color)">
+              {filteredPosts.length}
+            </Text>
             <Chip.Group value={currentFilter} onChange={setCurrentFilter}>
-              <Group position="center">
+              <Group position="center" mt="2rem">
                 <Chip value="recent">최신 순</Chip>
                 <Chip value="old">오래된 순</Chip>
               </Group>

--- a/client/src/components/community/PostItem.jsx
+++ b/client/src/components/community/PostItem.jsx
@@ -45,7 +45,7 @@ const PostDescription = styled(Group)`
 `;
 
 const PostItem = ({ post }) => {
-  const { id, title, createAt, category, completed, avatarId, certified, commentsLength } = post;
+  const { id, title, createAt, category, completed, avatarId, certified, commentsLength, productType } = post;
 
   return (
     <Post key={id} fz="15px" bg="var(--opacity-bg-color)">
@@ -65,17 +65,26 @@ const PostItem = ({ post }) => {
             </Flex>
           </PostDescription>
           <Flex ml="auto" direction="column" justify="space-between" align="flex-end">
-            <Badge
-              w={100}
-              size="lg"
-              variant="outline"
-              color={category === 'iPhone' ? 'red' : category === 'mac' ? 'green' : 'blue'}>
-              {category}
-            </Badge>
-            {/* 갖고 있는 기기 목록 Badge 추가 */}
-            <Text pr="0.8rem" c="var(--font-color)">
-              답글 {commentsLength}
-            </Text>
+            <Flex gap="8px" mt="4px">
+              <Badge
+                size="md"
+                variant="outline"
+                color={category === 'iPhone' ? 'red' : category === 'mac' ? 'green' : 'blue'}>
+                {category}
+              </Badge>
+              <Badge
+                size="md"
+                variant="filled"
+                color={category === 'iPhone' ? 'red' : category === 'mac' ? 'green' : 'blue'}>
+                {productType}
+              </Badge>
+            </Flex>
+            <Flex gap="4px" align="center" pr="0.8rem" fz="15px" c="var(--font-color)">
+              <Text>답글</Text>
+              <Text fz="16px" fw="600">
+                {commentsLength}
+              </Text>
+            </Flex>
           </Flex>
         </Flex>
       </PostLink>

--- a/client/src/components/community/UsefulCommentChip.jsx
+++ b/client/src/components/community/UsefulCommentChip.jsx
@@ -3,28 +3,32 @@ import { useParams } from 'react-router-dom';
 import { Chip } from '@mantine/core';
 import { useToggleCommentUsefulMutation } from '../../hooks/mutations';
 
-const UsefulCommentChip = ({ useful, commentId }) => {
+const UsefulCommentChip = ({ useful, commentId, oneOfCommentsIsUseful }) => {
   const [isUseful, setIsUseful] = React.useState(useful);
 
   const { postId } = useParams();
   const toggleUseful = useToggleCommentUsefulMutation(postId);
 
   return (
-    <Chip
-      checked={isUseful}
-      onChange={() => {
-        toggleUseful({ commentId, useful: !isUseful });
-        setIsUseful(isUseful => !isUseful);
-      }}
-      mb="4px"
-      ml="auto"
-      size="md"
-      fw="500"
-      radius="xl"
-      color="dark"
-      variant={isUseful ? 'outline' : 'filled'}>
-      유용한 답변으로 채택
-    </Chip>
+    <>
+      {((isUseful && oneOfCommentsIsUseful) || !oneOfCommentsIsUseful) && (
+        <Chip
+          checked={isUseful}
+          onChange={() => {
+            toggleUseful({ commentId, useful: !isUseful });
+            setIsUseful(isUseful => !isUseful);
+          }}
+          mb="4px"
+          ml="auto"
+          size="md"
+          fw="500"
+          radius="xl"
+          color="dark"
+          variant={isUseful ? 'outline' : 'filled'}>
+          유용한 답변으로 채택
+        </Chip>
+      )}
+    </>
   );
 };
 

--- a/client/src/components/profile/RegisterProductButton.jsx
+++ b/client/src/components/profile/RegisterProductButton.jsx
@@ -7,7 +7,7 @@ const RegisterProductButton = () => {
   const navigate = useNavigate();
 
   return (
-    <Button radius="sm" size="md" w="fit-content" onClick={() => navigate(REGISTER_PRODUCT_PATH)}>
+    <Button onClick={() => navigate(REGISTER_PRODUCT_PATH)} radius="xl" size="md" w="fit-content">
       기기 등록
     </Button>
   );

--- a/client/src/components/profile/UserProfile.jsx
+++ b/client/src/components/profile/UserProfile.jsx
@@ -113,7 +113,7 @@ const UserProfile = ({ nickName, avatarId, name, country, phoneNumber, point, le
                 <PointInfo>포인트 {point}</PointInfo>
               </SummaryRow>
 
-              <Button compact radius="sm" mt="5px" w="fit-content" onClick={handleEdit}>
+              <Button compact radius="10px" mt="5px" w="fit-content" onClick={handleEdit}>
                 프로필 편집
               </Button>
             </SummaryWrapper>

--- a/client/src/components/profile/UserProfileEditForm.jsx
+++ b/client/src/components/profile/UserProfileEditForm.jsx
@@ -115,7 +115,7 @@ const UserProfileEditForm = () => {
             <Textarea {...register('aboutMe')} />
           </InputWrapper>
 
-          <Button type="submit" mt="xl" size="lg">
+          <Button type="submit" mt="xl" size="lg" radius="10px">
             수정하기
           </Button>
         </Stack>

--- a/client/src/hooks/queries/useAutoCompleteQuery.js
+++ b/client/src/hooks/queries/useAutoCompleteQuery.js
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import React from 'react';
 
-const STALE_TIME = 3000;
+const staleTime = 3000;
 
 /**
  * @param {{
@@ -18,7 +18,7 @@ const useAutoCompleteQuery = ({ inputValue, queryFn, category }) => {
       const { data: posts } = await queryFn({ keyword: inputValue, category });
       return posts;
     },
-    staleTime: STALE_TIME,
+    staleTime,
     select: data => data.posts.map(post => ({ ...post, value: post.id })),
   });
 

--- a/client/src/pages/CommunityMe.jsx
+++ b/client/src/pages/CommunityMe.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import Recoil from 'recoil';
-import { Chip, Container, Flex, Group, Title } from '@mantine/core';
+import { Container, Title } from '@mantine/core';
 import { getMyPosts } from '../api/posts';
-import userState from '../recoil/atoms/userState';
 import { CommunityMyPosts, CommunitySkeleton } from '../components/community';
 
 const Wrapper = styled(Container)`
@@ -17,22 +15,19 @@ const Wrapper = styled(Container)`
   color: var(--font-color);
 `;
 
-const STALE_TIME = 3000;
+const staleTime = 3000;
 
-const communityMeQuery = userId => ({
-  queryKey: ['communityMe', userId],
+const communityMeQuery = () => ({
+  queryKey: ['communityMe'],
   queryFn: async () => {
-    const { data } = await getMyPosts(userId);
+    const { data } = await getMyPosts();
     return data;
   },
-  staleTime: STALE_TIME,
-  suspense: true,
+  staleTime,
 });
 
 const communityMeLoader = queryClient => async () => {
-  const loginUser = Recoil.useRecoilValue(userState);
-
-  const query = communityMeQuery(loginUser.email);
+  const query = communityMeQuery();
   // eslint-disable-next-line no-return-await
   return queryClient.getQueryData(query.queryKey) ?? (await queryClient.fetchQuery(query));
 };

--- a/client/src/pages/CommunityPost.jsx
+++ b/client/src/pages/CommunityPost.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import { Link, useLoaderData } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import { Container, Divider, Flex, Text } from '@mantine/core';
 import { BsArrowUpRightSquare } from 'react-icons/bs';
 import { COMMUNITY_PATH } from '../routes/routePaths';
@@ -41,7 +42,10 @@ export const communityPostLoader =
   };
 
 const CommunityPost = () => {
-  const post = useLoaderData();
+  const params = useParams();
+  const {
+    data: { post },
+  } = useQuery(communityPostQuery(params.postId));
 
   return (
     <Wrapper>

--- a/client/src/pages/CommunityPost.jsx
+++ b/client/src/pages/CommunityPost.jsx
@@ -57,7 +57,7 @@ const CommunityPost = () => {
       </Link>
       <PostContent post={post} />
       <Divider variant="dashed" />
-      <Comments />
+      <Comments postAuthor={post.author} />
     </Wrapper>
   );
 };

--- a/server/mock-data/comments.js
+++ b/server/mock-data/comments.js
@@ -41,7 +41,7 @@ let comments = [
 			'또한 분실하신 아이폰을 누군가 초기화하여 사용하려한다면 유석160님의 계정 비밀번호를 알아야만 활성화가 가능합니다.',
 		createAt: new Date('2023-01-26'),
 		updateAt: new Date(),
-		certified: true,
+		certified: false,
 		useful: false,
 	},
 	{
@@ -52,7 +52,7 @@ let comments = [
 			'또한 분실하신 아이폰을 누군가 초기화하여 사용하려한다면 유석160님의 계정 비밀번호를 알아야만 활성화가 가능합니다.',
 		createAt: new Date('2023-01-26'),
 		updateAt: new Date(),
-		certified: true,
+		certified: false,
 		useful: false,
 	},
 	{
@@ -63,7 +63,7 @@ let comments = [
 			'또한 분실하신 아이폰을 누군가 초기화하여 사용하려한다면 유석160님의 계정 비밀번호를 알아야만 활성화가 가능합니다.',
 		createAt: new Date('2023-01-26'),
 		updateAt: new Date(),
-		certified: true,
+		certified: false,
 		useful: false,
 	},
 	{
@@ -74,7 +74,7 @@ let comments = [
 			'또한 분실하신 아이폰을 누군가 초기화하여 사용하려한다면 유석160님의 계정 비밀번호를 알아야만 활성화가 가능합니다.',
 		createAt: new Date('2023-01-26'),
 		updateAt: new Date(),
-		certified: true,
+		certified: false,
 		useful: false,
 	},
 	{
@@ -85,7 +85,7 @@ let comments = [
 			'또한 분실하신 아이폰을 누군가 초기화하여 사용하려한다면 유석160님의 계정 비밀번호를 알아야만 활성화가 가능합니다.',
 		createAt: new Date('2023-01-26'),
 		updateAt: new Date(),
-		certified: true,
+		certified: false,
 		useful: false,
 	},
 	{
@@ -96,7 +96,7 @@ let comments = [
 			'또한 분실하신 아이폰을 누군가 초기화하여 사용하려한다면 유석160님의 계정 비밀번호를 알아야만 활성화가 가능합니다.',
 		createAt: new Date('2023-01-26'),
 		updateAt: new Date(),
-		certified: true,
+		certified: false,
 		useful: false,
 	},
 	{
@@ -107,7 +107,7 @@ let comments = [
 			'또한 분실하신 아이폰을 누군가 초기화하여 사용하려한다면 유석160님의 계정 비밀번호를 알아야만 활성화가 가능합니다.',
 		createAt: new Date('2023-01-26'),
 		updateAt: new Date(),
-		certified: true,
+		certified: false,
 		useful: false,
 	},
 	{
@@ -118,7 +118,7 @@ let comments = [
 			'또한 분실하신 아이폰을 누군가 초기화하여 사용하려한다면 유석160님의 계정 비밀번호를 알아야만 활성화가 가능합니다.',
 		createAt: new Date('2023-01-26'),
 		updateAt: new Date(),
-		certified: true,
+		certified: false,
 		useful: false,
 	},
 	{
@@ -129,7 +129,7 @@ let comments = [
 			'또한 분실하신 아이폰을 누군가 초기화하여 사용하려한다면 유석160님의 계정 비밀번호를 알아야만 활성화가 가능합니다.',
 		createAt: new Date('2023-01-26'),
 		updateAt: new Date(),
-		certified: true,
+		certified: false,
 		useful: false,
 	},
 	{
@@ -139,7 +139,7 @@ let comments = [
 		content: '음',
 		createAt: new Date(),
 		updateAt: new Date(),
-		certified: false,
+		certified: true,
 		useful: false,
 	},
 	{

--- a/server/mock-data/posts.js
+++ b/server/mock-data/posts.js
@@ -5,13 +5,15 @@ const comments = require('./comments');
  * 	{
 		id: uuidv,
 		title: string,
+		content: string,
 		author: string,
 		createAt: date,
 		updateAt: date,
-		comments: array[],
 		category: string,
 		productType: string,
 		completed: boolean,
+		certified: boolean,
+		comments?: array[],
 	},
  */
 
@@ -61,10 +63,10 @@ let posts = [
 		안드로이드폰에 유심침만 꼽아놓고 있습니다. 어떤사람은 6년.. 5년.. 같은제품을 써도 이런 증상이 없다고 하는데,
 		이런일이 있을수 있나요?`,
 		author: 'cooljp95@naver.com',
-		createAt: new Date('2022-11-01'),
+		createAt: new Date('2023-03-27'),
 		updateAt: new Date(),
 		category: 'iPhone',
-		productType: '',
+		productType: 'iphone-14',
 		completed: false,
 		certified: true,
 	},
@@ -72,36 +74,50 @@ let posts = [
 	{
 		id: '2',
 		title: '아이폰12 메인보드 고장이 연속으로 났습니다.',
-		content: '',
+		content: `워낙 휴대폰을 애지중지 사용하고있느라, 애플케어 및 통신사보험을 사용하지 않고있습니다.
+		물에 빠트리거나, 간단한 충격조차 없었고요, 작년 여름 정식수리업체에서 메인보드 결함 판정 후 무상수리,
+		메인보드 교체받았습니다. 물론 데이터는 1도 복구 못하였구요..
+		당시 교체시 카메라와 액정? 빼고 전체 '새 제품'으로 교체가 되었다고 말씀하더군요.
+		(작년 여름 사무실에서 가만히 멜론어플 사용중 전원OFF 후 켜지지 않았음)
+		그 같은 증상이 지난 4월20일, 수리한지 1년도 되지 않아 발생하였습니다.
+		또 방문을 했지요. 메인보드 교체 후 90일 이내 무상이라고 하네요. 결국 58만7천원을 수리비로 내야한다고 합니다.
+		너무 어이가 없고 억울하네요. 사운드결함은 있다고 들었는데 어떻게하면 새 제품이 1년도 안 되서 똑같이 발생할 수가 있을까요.
+		교체 한 메인보드 조차 결함이 있던건 아닐까요.
+		60만원이라는 거금을 투자해서 다시 수리를 해도 또 같은 증상이 발생하면 또 60만원이라는 큰 돈이 나가겠지요.
+		수리 못하고있습니다. 6년된 안드로이드폰에 유심침만 꼽아놓고 있습니다.
+		어떤사람은 6년.. 5년.. 같은제품을 써도 이런 증상이 없다고 하는데, 이런일이 있을수 있나요?
+		
+		`,
 		author: 'kylekwon.dev@gmail.com',
-		createAt: new Date('2022-12-01'),
+		createAt: new Date('2023-03-21'),
 		updateAt: new Date(),
 		category: 'iPhone',
-		productType: '',
+		productType: 'iphone-12',
 		completed: false,
-		certified: false,
+		certified: true,
 	},
 	{
 		id: '3',
-		title: '애플워치 건강 기능에 문제가 있어요',
+		title: '아이폰 건강 기능에 문제가 있어요',
 		content: '',
 		author: 'cooljp95@naver.com',
-		createAt: new Date('2022-12-15'),
+		createAt: new Date('2023-03-14'),
 		updateAt: new Date(),
 		category: 'iPhone',
-		productType: '',
+		productType: 'iphone-14-pro',
 		completed: false,
 		certified: false,
 	},
 	{
 		id: '4',
-		title: '에어팟 한쪽 귀가 안들리는데 충전을 잘못 한 걸까요?',
+		title:
+			'아이폰에 에어팟 연결했을 때 한쪽 귀가 안들리는데 충전을 잘못 한 걸까요?',
 		content: '',
 		author: 'kylekwon.dev@gmail.com',
-		createAt: new Date('2022-12-24'),
+		createAt: new Date('2023-03-09'),
 		updateAt: new Date(),
 		category: 'iPhone',
-		productType: '',
+		productType: 'iphone-13',
 		completed: true,
 		certified: false,
 	},
@@ -111,10 +127,10 @@ let posts = [
 			'집중모드 위치설정 기기변경을 하려하는데 예전 폰으로 위치 설정이 잡히는데 어떻게 하는게 좋을까요?',
 		content: '',
 		author: 'cooljp95@naver.com',
-		createAt: new Date('2022-12-31'),
+		createAt: new Date('2023-03-02'),
 		updateAt: new Date(),
 		category: 'iPhone',
-		productType: '',
+		productType: 'iphone-14',
 		completed: false,
 		certified: false,
 	},
@@ -123,10 +139,10 @@ let posts = [
 		title: 'm1 맥북에어 최대 충전속도가 어떻게 되나요?',
 		content: '',
 		author: 'kylekwon.dev@gmail.com',
-		createAt: new Date('2023-01-01'),
+		createAt: new Date('2023-02-21'),
 		updateAt: new Date(),
 		category: 'Mac',
-		productType: '',
+		productType: 'macbook-air-m1',
 		completed: false,
 		certified: false,
 	},
@@ -135,10 +151,10 @@ let posts = [
 		title: '맥북 이미지 캡처로 외장하드에 사진 옮기기',
 		content: '',
 		author: 'kylekwon.dev@gmail.com',
-		createAt: new Date('2023-01-31'),
+		createAt: new Date('2023-02-14'),
 		updateAt: new Date(),
 		category: 'Mac',
-		productType: '',
+		productType: 'macbook-pro-16',
 		completed: false,
 		certified: false,
 	},
@@ -147,10 +163,10 @@ let posts = [
 		title: '맥북의 경우 trade in 어떻게 가능한가요?',
 		content: '',
 		author: 'cooljp95@naver.com',
-		createAt: new Date('2023-02-01'),
+		createAt: new Date('2023-02-05'),
 		updateAt: new Date(),
 		category: 'Mac',
-		productType: '',
+		productType: 'macbook-pro-13',
 		completed: true,
 		certified: false,
 	},
@@ -159,10 +175,10 @@ let posts = [
 		title: '맥북 잠자기 프리징현상',
 		content: '',
 		author: 'cooljp95@naver.com',
-		createAt: new Date('2023-02-28'),
+		createAt: new Date('2023-02-01'),
 		updateAt: new Date(),
 		category: 'Mac',
-		productType: '',
+		productType: 'macbook-pro-14',
 		completed: false,
 		certified: false,
 	},
@@ -171,10 +187,74 @@ let posts = [
 		title: '맥북 프로 화면 닦을 때 권장사항 또는 주의해야할 점 궁금합니다',
 		content: '',
 		author: 'kylekwon.dev@gmail.com',
-		createAt: new Date('2023-03-01'),
+		createAt: new Date('2023-01-19'),
 		updateAt: new Date(),
 		category: 'Mac',
-		productType: '',
+		productType: 'macbook-pro-16',
+		completed: false,
+		certified: false,
+	},
+	{
+		id: '11',
+		title:
+			'아이패드 ios 16 이후 버전에서 키보드 마우스 동시 사용시 동작이 이상합니다. 저와 같은 현상을 겪으시는분은 없으신가요?',
+		content: '',
+		author: 'qwer@qwer.ee',
+		createAt: new Date('2023-01-12'),
+		updateAt: new Date(),
+		category: 'Ipad',
+		productType: 'ipad-pro',
+		completed: false,
+		certified: false,
+	},
+	{
+		id: '12',
+		title: '쿠팡에서 산 패드 교환을 공식스토어에서도 해주나요?',
+		content: '',
+		author: 'qwer@qwer.ee',
+		createAt: new Date('2023-01-08'),
+		updateAt: new Date(),
+		category: 'Ipad',
+		productType: 'ipad-air',
+		completed: false,
+		certified: false,
+	},
+	{
+		id: '13',
+		title:
+			'아이패드 프로6세대 12.9인치 디스플레이에 습기 찬거 같은 뿌옅고 흰색번짐 현상이 계속 나타나는데 불량인가요?',
+		content: '',
+		author: 'qwer@qwer.ee',
+		createAt: new Date('2023-01-02'),
+		updateAt: new Date(),
+		category: 'Ipad',
+		productType: 'ipad-pro',
+		completed: false,
+		certified: false,
+	},
+
+	{
+		id: '14',
+		title:
+			'맥북에서 아이패드로 에어드롭 실패 문제가 자주 발생하는데 어떤 근본적인 해결책은 없나요?',
+		content: '',
+		author: 'qwer@qwer.ee',
+		createAt: new Date('2022-12-24'),
+		updateAt: new Date(),
+		category: 'Ipad',
+		productType: 'ipad-basic',
+		completed: false,
+		certified: false,
+	},
+	{
+		id: '15',
+		title: '애플 정품 20w 충전기로 아이패드 미니 6세대 충전해도 괜찮나요?',
+		content: '',
+		author: 'qwer@qwer.ee',
+		createAt: new Date('2022-12-12'),
+		updateAt: new Date(),
+		category: 'Ipad',
+		productType: 'ipad-mini',
 		completed: false,
 		certified: false,
 	},
@@ -182,7 +262,7 @@ let posts = [
 
 const getPosts = () => posts;
 
-const getFilteredPosts = (category) => {
+const getFilteredPosts = (category = '') => {
 	return category === ''
 		? posts
 		: posts.filter((post) => post.category.toLowerCase() === category);
@@ -226,8 +306,8 @@ const deletePost = (postId) =>
 	(posts = posts.filter(({ id }) => id !== postId));
 
 // Autocomplete Search Posts -> Max Count :5
-const searchPost = (posts, keyword) => {
-	return posts.filter((post) => new RegExp(keyword, 'i').test(post.title));
+const searchPost = (posts, keyword = '') => {
+	return posts.filter(({ title }) => new RegExp(keyword, 'i').test(title));
 };
 
 module.exports = {

--- a/server/mock-data/users.js
+++ b/server/mock-data/users.js
@@ -97,7 +97,6 @@ let users = [
 		phoneNumber: '010-1111-0615',
 		products: [
 			{ type: 'ipad-pro' },
-			{ type: 'ipad-pro' },
 			{ type: 'iphone-13' },
 			{ type: 'iphone-14' },
 			{ type: 'iphone-14-pro' },
@@ -105,7 +104,7 @@ let users = [
 		],
 		point: 250,
 		level: 3,
-		avatarId: 'avatar-10',
+		avatarId: 'avatar-0',
 		aboutMe: 'junior fe dev',
 	},
 	{


### PR DESCRIPTION
### Change
---
- `CommunityMe` 페이지 사용자 인증 관련 이슈 해결 및 UI 추가/수정
- `staleTime` 상수 PascalCase -> camelCase로 수정 및 통일
- `productType` 데이터 추가로 Badge UI cnrk
- `UserProfile`, `UserEdit` 페이지 내 버튼 border 스타일 수정
- `useLoaderData` -> `useQuery`로 캐시된 데이터 Fetch 하는 방법 수정
- `CommunityPost` 페이지 답글 관련 UI 변경 및 로직 재구성
- `comments` mock-data `certified` property 업데이트
- `post` mock-data productType 정의
- 일부 user `avatar-id` 수정
- 내가 작성한 글 목록 GET api userId 관련 로직 추가
