### PR TITLE
[REFAC] : SideFilter 컴포넌트 UI 및 렌더링 방법 리팩토링 및 CommunityCategory 페이지 컴포넌트 분리

### DIFF
--- a/client/src/components/community/CommunityCategorySection.jsx
+++ b/client/src/components/community/CommunityCategorySection.jsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { Link, useParams } from 'react-router-dom';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useDisclosure } from '@mantine/hooks';
+import { Burger, Divider, Flex, List, Text, Title, Image } from '@mantine/core';
+import { FiArrowRight } from 'react-icons/fi';
+import { BsArrowUpRightSquare } from 'react-icons/bs';
+import { COMMUNITY_PATH } from '../../routes/routePaths';
+import { getSearchedPosts } from '../../api/posts';
+import { categoryQuery } from '../../pages/CommunityCategory';
+import FILTERS from '../../constants/filters';
+import { category as CATEGORY } from '../../constants/category';
+import { AutoComplete, EmptyPostIndicator, SideFilter, PostItem, ShowMoreButton } from '.';
+
+const CategoryImage = styled(Image)`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-right: 2rem;
+
+  figure.mantine-Image-figure {
+    width: ${({ category }) => (category === 'mac' ? '90%' : category === 'ipad' ? '65%' : '70%')};
+  }
+`;
+
+const PostsContainer = styled(Flex)`
+  margin-top: 1rem;
+  width: 100%;
+  overflow: hidden;
+`;
+
+const CategoryPosts = styled(List)`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 3rem;
+  width: 100%;
+`;
+
+const CommunityCategorySection = () => {
+  const { category } = useParams();
+
+  const { data, hasNextPage, isFetchingNextPage, fetchNextPage } = useInfiniteQuery(categoryQuery(category));
+
+  const [opened, { toggle }] = useDisclosure(false);
+  const [currentFilter, setCurrentFilter] = React.useState(FILTERS.all);
+
+  const filteredPosts =
+    data?.posts.filter(post =>
+      currentFilter === FILTERS.active
+        ? !post.completed
+        : currentFilter === FILTERS.completed
+        ? post.completed
+        : currentFilter === FILTERS.certified
+        ? post.certified
+        : true
+    ) ?? [];
+
+  return (
+    <>
+      <Flex>
+        <Link to={`${COMMUNITY_PATH}`}>
+          <Flex gap="5px" align="center" mr="5px" fz="15px" fw="600" td="none" c="var(--font-color)">
+            <Text>Community</Text>
+            <FiArrowRight />
+          </Flex>
+        </Link>
+        <Link to={`${COMMUNITY_PATH}/${category}`}>
+          <Flex gap="5px" align="center" fz="15px" fw="600" td="none" c="var(--font-color)">
+            <Text>{CATEGORY[category]}</Text>
+            <BsArrowUpRightSquare />
+          </Flex>
+        </Link>
+      </Flex>
+
+      <Flex gap="0.5rem" mt="4rem">
+        <CategoryImage
+          src={`/community/${category}/${category}-category.png`}
+          alt={`${category}-category-img`}
+          category={category}
+        />
+        <Flex direction="column" justify="center">
+          <Title mb="3rem">{CATEGORY[category]}</Title>
+          <AutoComplete width={720} queryFn={getSearchedPosts} category={category} />
+        </Flex>
+      </Flex>
+      <Flex gap="10px" mt="5.5rem" mb="10px" align="center" fw="600">
+        <Text fz="2rem" fw="600" mt="1px">
+          질문
+        </Text>
+        <Text c="blue" fz="2.5rem">
+          {data?.totalLength}
+        </Text>
+      </Flex>
+
+      <Divider mb="1rem" variant="dashed" />
+      <Flex pos="relative">
+        <Burger
+          opened={opened}
+          onClick={toggle}
+          pos="absolute"
+          top="0.5rem"
+          left="0"
+          color="var(--font-color)"
+          aria-label={opened ? 'Close' : 'Open'}
+        />
+        <PostsContainer>
+          <SideFilter open={opened} currentFilter={currentFilter} setCurrentFilter={setCurrentFilter} />
+          {filteredPosts.length === 0 ? (
+            <EmptyPostIndicator />
+          ) : (
+            <CategoryPosts>
+              {filteredPosts.map(post => (
+                <PostItem key={post.id} post={post} />
+              ))}
+            </CategoryPosts>
+          )}
+        </PostsContainer>
+      </Flex>
+      {hasNextPage && <ShowMoreButton loading={isFetchingNextPage} onClick={fetchNextPage} />}
+    </>
+  );
+};
+
+export default CommunityCategorySection;

--- a/client/src/components/community/CommunityMyPosts.jsx
+++ b/client/src/components/community/CommunityMyPosts.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { useQuery } from '@tanstack/react-query';
 import { Chip, Flex, Group, List, Text } from '@mantine/core';
-import { EmptyPostIndicator, PostItem } from '.';
 import { communityMeQuery } from '../../pages/CommunityMe';
+import { EmptyPostIndicator, PostItem } from '.';
 
 const MyPosts = styled(List)`
   display: flex;

--- a/client/src/components/community/EmptyPostIndicator.jsx
+++ b/client/src/components/community/EmptyPostIndicator.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import { Button, Flex, Title } from '@mantine/core';
 import { useNavigate } from 'react-router-dom';
+import { Button, Flex, Title } from '@mantine/core';
 import { COMMUNITY_QUESTION_PATH } from '../../routes/routePaths';
 
 const Container = styled(Flex)`

--- a/client/src/components/community/PostContent.jsx
+++ b/client/src/components/community/PostContent.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import { Link } from 'react-router-dom';
 import { Badge, Flex, Text, Title } from '@mantine/core';
+import { BsArrowUpRightSquare } from 'react-icons/bs';
 import formattedDate from '../../utils/formattedDate';
 import { ProfileAvatar } from '../common';
-import CheckedCircleIcon from './CheckedCircleIcon';
-import AppleRecommendIcon from './AppleRecommendIcon';
+import { CheckedCircleIcon, AppleRecommendIcon } from '.';
+import { COMMUNITY_PATH } from '../../routes/routePaths';
 
 const PostSection = styled.section`
   margin-top: 2.5rem;
@@ -36,38 +38,46 @@ const Content = styled(Text)`
 `;
 
 const PostContent = ({ post }) => {
-  const { title, createAt, content, completed, avatarId, certified, nickName, level, point } = post;
+  const { title, category, createAt, content, completed, avatarId, certified, nickName, level, point } = post;
 
   return (
-    <PostSection>
-      <Flex gap="1rem" mb="0.5rem" ml="auto" h="30px">
-        <CheckedCircleIcon completed={completed} />
-        {certified && <AppleRecommendIcon />}
-      </Flex>
-
-      <PostTitle>{title}</PostTitle>
-
-      <Text mt="0.5rem" ml="0.2rem" fz="15px" c="grey">
-        {formattedDate(new Date(createAt))}
-      </Text>
-      <AuthorProfile>
-        <ProfileAvatar avatarId={avatarId} />
-        <Flex display="flex" gap="10px" direction="column">
-          <Text mt="-3px" ml="2px" fz="21px" fw="500">
-            {nickName}
-          </Text>
-          <Flex gap="8px" align="center">
-            <Badge variant="outline" size="lg" fz="14px">
-              레벨 {level}
-            </Badge>
-            <Badge variant="outline" size="lg" fz="14px">
-              포인트 {point}
-            </Badge>
-          </Flex>
+    <>
+      <Link to={`${COMMUNITY_PATH}/${category.toLowerCase()}`}>
+        <Flex gap="5px" align="center" fz="15px" fw="600" td="none" c="var(--font-color)">
+          <Text>{category}</Text>
+          <BsArrowUpRightSquare />
         </Flex>
-      </AuthorProfile>
-      <Content>{content}</Content>
-    </PostSection>
+      </Link>
+      <PostSection>
+        <Flex gap="1rem" mb="0.5rem" ml="auto" h="30px">
+          <CheckedCircleIcon completed={completed} />
+          {certified && <AppleRecommendIcon />}
+        </Flex>
+
+        <PostTitle>{title}</PostTitle>
+
+        <Text mt="0.5rem" ml="0.2rem" fz="15px" c="grey">
+          {formattedDate(new Date(createAt))}
+        </Text>
+        <AuthorProfile>
+          <ProfileAvatar avatarId={avatarId} />
+          <Flex display="flex" gap="10px" direction="column">
+            <Text mt="-3px" ml="2px" fz="21px" fw="500">
+              {nickName}
+            </Text>
+            <Flex gap="8px" align="center">
+              <Badge variant="outline" size="lg" fz="14px">
+                레벨 {level}
+              </Badge>
+              <Badge variant="outline" size="lg" fz="14px">
+                포인트 {point}
+              </Badge>
+            </Flex>
+          </Flex>
+        </AuthorProfile>
+        <Content>{content}</Content>
+      </PostSection>
+    </>
   );
 };
 

--- a/client/src/components/community/PostItem.jsx
+++ b/client/src/components/community/PostItem.jsx
@@ -3,11 +3,9 @@ import styled from '@emotion/styled';
 import { Link } from 'react-router-dom';
 import { Badge, Flex, Group, List, Text, Title } from '@mantine/core';
 import { COMMUNITY_POST_PATH } from '../../routes/routePaths';
-
 import formattedDate from '../../utils/formattedDate';
-import AppleRecommendIcon from './AppleRecommendIcon';
-import CheckedCircleIcon from './CheckedCircleIcon';
 import { ProfileAvatar } from '../common';
+import { AppleRecommendIcon, CheckedCircleIcon } from '.';
 
 const Post = styled(List.Item)`
   border: 1px solid var(--opacity-border-color);

--- a/client/src/components/community/SideFilter.jsx
+++ b/client/src/components/community/SideFilter.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Text, Box, NavLink, Stack } from '@mantine/core';
 import styled from '@emotion/styled';
+import { Text, Box, NavLink, Stack } from '@mantine/core';
 import FILTERS from '../../constants/filters';
 
 const Container = styled(Box)`
@@ -25,15 +25,39 @@ const Container = styled(Box)`
   }
 `;
 
-const SideFilter = ({ open, setCurrentFilter }) => (
+const navLinkList = [
+  {
+    title: '전체보기',
+    filter: FILTERS.all,
+  },
+  {
+    title: '해결된 질문',
+    filter: FILTERS.completed,
+  },
+  {
+    title: 'FineApple 권장 답변',
+    filter: FILTERS.certified,
+  },
+  {
+    title: '해결되지 않은 질문',
+    filter: FILTERS.active,
+  },
+];
+
+const SideFilter = ({ open, currentFilter, setCurrentFilter }) => (
   <Container open={open}>
     <Text fz="20px" fw="600">
       유형
     </Text>
     <Stack my="xl" spacing="xl">
-      <NavLink label="해결된 질문" onClick={() => setCurrentFilter(FILTERS.completed)} />
-      <NavLink label="FineApple 권장 답변" onClick={() => setCurrentFilter(FILTERS.certified)} />
-      <NavLink label="해결되지 않은 질문" onClick={() => setCurrentFilter(FILTERS.active)} />
+      {navLinkList.map(({ title, filter }) => (
+        <NavLink
+          key={filter}
+          label={title}
+          active={currentFilter === filter}
+          onClick={() => setCurrentFilter(filter)}
+        />
+      ))}
     </Stack>
   </Container>
 );

--- a/client/src/components/community/index.js
+++ b/client/src/components/community/index.js
@@ -24,3 +24,4 @@ export { default as PostItem } from './PostItem';
 export { default as EmptyPostIndicator } from './EmptyPostIndicator';
 export { default as ShowMoreButton } from './ShowMoreButton';
 export { default as UsefulCommentChip } from './UsefulCommentChip';
+export { default as CommunityCategorySection } from './CommunityCategorySection';

--- a/client/src/pages/CommunityCategory.jsx
+++ b/client/src/pages/CommunityCategory.jsx
@@ -1,15 +1,8 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import { Link, useParams } from 'react-router-dom';
-import { BsArrowUpRightSquare } from 'react-icons/bs';
-import { useInfiniteQuery } from '@tanstack/react-query';
-import { useDisclosure } from '@mantine/hooks';
-import { Burger, Container, Divider, Flex, Image, List, Text, Title } from '@mantine/core';
-import { FiArrowRight } from 'react-icons/fi';
-import { COMMUNITY_PATH } from '../routes/routePaths';
-import { AutoComplete, EmptyPostIndicator, PostItem, ShowMoreButton, SideFilter } from '../components/community';
-import { getPostsByCategory, getSearchedPosts } from '../api/posts';
-import FILTERS from '../constants/filters';
+import { Container } from '@mantine/core';
+import { CommunityCategorySection } from '../components/community';
+import { getPostsByCategory } from '../api/posts';
 
 const Wrapper = styled(Container)`
   min-width: 1024px;
@@ -21,37 +14,6 @@ const Wrapper = styled(Container)`
   font-size: 0.75rem;
   color: var(--font-color);
 `;
-
-const CategoryImage = styled(Image)`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin-right: 2rem;
-
-  figure.mantine-Image-figure {
-    width: ${({ category }) => (category === 'mac' ? '90%' : category === 'ipad' ? '65%' : '70%')};
-  }
-`;
-
-const PostsContainer = styled(Flex)`
-  margin-top: 1rem;
-  width: 100%;
-  overflow: hidden;
-`;
-
-const CategoryPosts = styled(List)`
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  margin-top: 3rem;
-  width: 100%;
-`;
-
-const CATEGORY = {
-  iphone: 'iPhone',
-  ipad: 'iPad',
-  mac: 'Mac',
-};
 
 const staleTime = 3000;
 
@@ -83,89 +45,11 @@ export const communityCategoryLoader =
     return queryClient.getQueryData(query.queryKey) ?? (await queryClient.fetchInfiniteQuery(query));
   };
 
-const CommunityCategory = () => {
-  const { category } = useParams();
+const CommunityCategory = () => (
+  <Wrapper>
+    <CommunityCategorySection />
+  </Wrapper>
+);
 
-  const { data, hasNextPage, isFetchingNextPage, fetchNextPage } = useInfiniteQuery(categoryQuery(category));
-
-  const [opened, { toggle }] = useDisclosure(false);
-  const [currentFilter, setCurrentFilter] = React.useState(FILTERS.all);
-
-  const filteredPosts =
-    data?.posts.filter(post =>
-      currentFilter === FILTERS.active
-        ? !post.completed
-        : currentFilter === FILTERS.completed
-        ? post.completed
-        : currentFilter === FILTERS.certified
-        ? post.certified
-        : true
-    ) ?? [];
-
-  return (
-    <Wrapper>
-      <Flex>
-        <Link to={`${COMMUNITY_PATH}`}>
-          <Flex gap="5px" align="center" mr="5px" fz="15px" fw="600" td="none" c="var(--font-color)">
-            <Text>Community</Text>
-            <FiArrowRight />
-          </Flex>
-        </Link>
-        <Link to={`${COMMUNITY_PATH}/${category}`}>
-          <Flex gap="5px" align="center" fz="15px" fw="600" td="none" c="var(--font-color)">
-            <Text>{CATEGORY[category]}</Text>
-            <BsArrowUpRightSquare />
-          </Flex>
-        </Link>
-      </Flex>
-      <Flex gap="0.5rem" mt="2rem">
-        <CategoryImage
-          src={`/community/${category}/${category}-category.png`}
-          alt={`${category}-category-img`}
-          category={category}
-        />
-        <Flex direction="column" justify="center">
-          <Title mb="3rem">{CATEGORY[category]}</Title>
-          <AutoComplete width={720} queryFn={getSearchedPosts} category={category} />
-        </Flex>
-      </Flex>
-
-      <Flex gap="10px" mt="6rem" mb="1rem" align="center" fw="600">
-        <Text fz="2rem" fw="600" mt="1px">
-          질문
-        </Text>
-        <Text c="blue" fz="2.5rem">
-          {data?.totalLength}
-        </Text>
-      </Flex>
-
-      <Divider mb="1rem" variant="dashed" />
-      <Flex pos="relative">
-        <Burger
-          opened={opened}
-          onClick={toggle}
-          pos="absolute"
-          top="0.5rem"
-          left="0"
-          color="var(--font-color)"
-          aria-label={opened ? 'Close' : 'Open'}
-        />
-        <PostsContainer>
-          <SideFilter open={opened} setCurrentFilter={setCurrentFilter} />
-          {filteredPosts.length === 0 ? (
-            <EmptyPostIndicator />
-          ) : (
-            <CategoryPosts>
-              {filteredPosts.map(post => (
-                <PostItem key={post.id} post={post} />
-              ))}
-            </CategoryPosts>
-          )}
-        </PostsContainer>
-      </Flex>
-      {hasNextPage && <ShowMoreButton loading={isFetchingNextPage} onClick={fetchNextPage} />}
-    </Wrapper>
-  );
-};
-
+export { categoryQuery };
 export default CommunityCategory;

--- a/client/src/pages/CommunityPost.jsx
+++ b/client/src/pages/CommunityPost.jsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import { Link, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { Container, Divider, Flex, Text } from '@mantine/core';
-import { BsArrowUpRightSquare } from 'react-icons/bs';
-import { COMMUNITY_PATH } from '../routes/routePaths';
+import { Container, Divider } from '@mantine/core';
 import { getPost } from '../api/post';
 import Comments from '../components/community/Comments';
 import PostContent from '../components/community/PostContent';
@@ -49,12 +47,6 @@ const CommunityPost = () => {
 
   return (
     <Wrapper>
-      <Link to={`${COMMUNITY_PATH}/${post.category.toLowerCase()}`}>
-        <Flex gap="5px" align="center" fz="15px" fw="600" td="none" c="var(--font-color)">
-          <Text>{post.category}</Text>
-          <BsArrowUpRightSquare />
-        </Flex>
-      </Link>
       <PostContent post={post} />
       <Divider variant="dashed" />
       <Comments postAuthor={post.author} />


### PR DESCRIPTION
### Change
---
- `CommunityCategory` 컴포넌트 분리
- import 문 순서 및 경로 수정
- `SideFilter` 컴포넌트 UI 및 렌더링 방법 리팩토링
- export 대상(`CommunityCategorySection`) 추가 (`'/community/index.js'`) 
- `CommunityPost` 페이지 Link BreadCrumb 컴포넌트 위치 수정
