### PR TITLE
[FEAT] Question Form 전송 성공 / 실패 처리

### DIFF
--- a/client/src/components/common/Toast.jsx
+++ b/client/src/components/common/Toast.jsx
@@ -60,18 +60,27 @@ const animation = {
   },
 };
 
+const bgc = {
+  success: '#339af0',
+  error: '#ff6b6b',
+};
+
 const Container = styled.div`
-  position: ${({ fixed }) => fixed && 'fixed'};
+  position: fixed;
   top: ${({ position }) => position === 'top' && '0'};
   bottom: ${({ position }) => position === 'bottom' && '0'};
   width: 100%;
   height: ${({ h }) => h};
   padding: 12px 12px;
   background-color: ${({ bgc }) => bgc};
-  color: ${({ c }) => c};
+  color: #fff;
 
   animation: ${({ position, status }) => animation[position][status]} 0.5s both;
   z-index: 9999;
+
+  button {
+    color: #fff;
+  }
 `;
 
 const ToastCloseButton = styled(CloseButton)`
@@ -84,26 +93,20 @@ const ToastCloseButton = styled(CloseButton)`
  * c : toast 폰트 컬러 / string
  * bgc : toast 배경 컬러 / string
  *
- * fixed : toast fixed 속성 여부 / boolean
- *         true일 경우 상단 / 하단에 고정되서 등장
- *         false일 경우 아래 요소들을 밀어내면서 등장
- *
  * position : toast가 등장할 위치  / 'top' | 'bottom'
  * closeOnClick : toast 닫기 버튼 노출 여부 / boolean
  * autoClose : 딜레이 이후 자동으로 toast 삭제 여부 / boolean
  * autoCloseDelay : 자동으로 toast 삭제 시, 딜레이 지정 / number
  * children : toast에 포함할 내용 / jsx
  *
- * @param {{h, c, bgc, fixed, position, closeOnClick, autoClose, autoCloseDelay, children}}
+ * @param {{h, c, bgc, position, closeOnClick, autoClose, autoCloseDelay, children}}
  * @returns
  */
 
 const Toast = ({
   id,
   h = '50px',
-  c = '#fff',
-  bgc = '#339af0',
-  fixed = true,
+  type = 'success',
   position = 'top',
   closeOnClick = true,
   autoClose = true,
@@ -119,22 +122,9 @@ const Toast = ({
   };
 
   return (
-    <Container
-      status={status}
-      position={position}
-      onAnimationEnd={handleAnimationEnd}
-      fixed={fixed}
-      h={h}
-      c={c}
-      bgc={bgc}>
+    <Container status={status} position={position} onAnimationEnd={handleAnimationEnd} h={h} bgc={bgc[type]}>
       {closeOnClick && (
-        <ToastCloseButton
-          onClick={() => setStatus('dismiss')}
-          c={c}
-          iconSize="24px"
-          variant="transparent"
-          right="2.5%"
-        />
+        <ToastCloseButton onClick={() => setStatus('dismiss')} iconSize="24px" variant="transparent" right="2.5%" />
       )}
       <Center px="5%">{message}</Center>
     </Container>

--- a/client/src/components/community/ContentEditor.jsx
+++ b/client/src/components/community/ContentEditor.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useController } from 'react-hook-form';
+import useTextEditor from '../../hooks/useTextEditor';
+import { TextEditor } from '.';
+
+/**
+ * isValid가 업데이트 되도록 TextEditor를 controlled로 사용한다.
+ * 따로 컴포넌트를 뺼지 말지 고민 (QuestionForm 컴포넌트는 onSubmit 로직에만 집중)
+ */
+
+const ContentEditor = ({ name, control }) => {
+  const {
+    field: { value, onChange },
+  } = useController({ name, control });
+
+  const editor = useTextEditor({
+    initContent: value,
+    placeholder: '질문이 무엇입니까?',
+    option: {
+      onUpdate: ({ editor }) => onChange(editor.getHTML()),
+    },
+  });
+
+  return <TextEditor editor={editor} />;
+};
+
+export default ContentEditor;

--- a/client/src/components/community/MyProductListPanel.jsx
+++ b/client/src/components/community/MyProductListPanel.jsx
@@ -66,7 +66,7 @@ const MyProductListPanel = ({ products, selectedProductType, onSelectProduct }) 
           checked={selectedProductType === productType}
           value={productType}
           onClick={() => {
-            onSelectProduct(productType);
+            if (onSelectProduct) onSelectProduct(productType);
           }}
           label={
             <ItemCard>

--- a/client/src/components/community/index.js
+++ b/client/src/components/community/index.js
@@ -14,6 +14,7 @@ export { default as SelectedCategoryAndProductType } from './SelectedCategoryAnd
 export { default as MyProductListPanel } from './MyProductListPanel';
 export { default as QuestionForm } from './QuestionForm';
 export { default as SubjectSelect } from './SubjectSelect';
+export { default as ContentEditor } from './ContentEditor';
 export { default as CheckedCircleIcon } from './CheckedCircleIcon';
 export { default as AppleRecommendIcon } from './AppleRecommendIcon';
 export { default as RankTable } from './RankTable';

--- a/client/src/hooks/useToast.js
+++ b/client/src/hooks/useToast.js
@@ -14,7 +14,15 @@ const useToast = () => {
     setToasts(toasts => toasts.filter(toast => toast.id !== toastId));
   };
 
-  return { create, remove };
+  const success = toastInfo => {
+    create({ ...toastInfo, type: 'success' });
+  };
+
+  const error = toastInfo => {
+    create({ ...toastInfo, type: 'error' });
+  };
+
+  return { create, remove, success, error };
 };
 
 export default useToast;


### PR DESCRIPTION
### Change
---
- QuestionForm 전송 시 띄울 토스트를 구분하기 위해 토스트에 타입 추가.
- 기존 토스트를 사용하던 곳을 그대로 사용할 수 있도록  create 삭제하지 않음

- QuestionForm 전송 성공 시, 토스트 띄우기, 해당 카테고리 페이지로 이동 처리
- QuestionForm 전송 실패 시, 토스트 띄우기

- TextEditor의 validation 체크가 바로 적용되지 않는 문제를 해결하기 위해 useController를 사용.
- 따라서 TextEditor를 따로 컴포넌트를 분리.



