### PR TITLE
[FEAT] : CommunityMain 컴포넌트 페이지로 이동 및 NotFound 페이지 추가

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -5,7 +5,17 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { Global } from '@emotion/react';
 import GlobalStyle from './styles/GlobalStyle';
 import AuthenticationGuard from './guard/AuthenticationGuard';
-import { Community, CommunityPost, ProfileEdit, Question, RegisterProduct, SignIn, SignUp } from './pages';
+import {
+  Community,
+  CommunityMain,
+  CommunityPost,
+  NotFound,
+  ProfileEdit,
+  Question,
+  RegisterProduct,
+  SignIn,
+  SignUp,
+} from './pages';
 import CommunityMe, { communityMeLoader } from './pages/CommunityMe';
 import Profile, { profileLoader } from './pages/Profile';
 import { communityPostLoader } from './pages/CommunityPost';
@@ -13,9 +23,6 @@ import Rank, { rankLoader } from './pages/Rank';
 import { Layout } from './components';
 import { SIGNIN_PATH } from './routes/routePaths';
 import CommunityCategory, { communityCategoryLoader } from './pages/CommunityCategory';
-
-// TODO : CommunityMain Page로 이동할지 논의하기
-import { CommunityMain } from './components/community';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -81,6 +88,10 @@ const router = createBrowserRouter([
       {
         path: '/profile/register',
         element: <AuthenticationGuard redirectTo={SIGNIN_PATH} element={<RegisterProduct />} />,
+      },
+      {
+        path: '*',
+        element: <NotFound />,
       },
     ],
   },

--- a/client/src/components/community/Comments.jsx
+++ b/client/src/components/community/Comments.jsx
@@ -108,7 +108,7 @@ const Comments = ({ postAuthor }) => {
           />
         ))}
       </CommentList>
-      <Divider mt="2rem" variant="dashed" />
+      {filteredComments.length > 0 && <Divider mt="2rem" variant="dashed" />}
       <Container miw="990px" my="20px" ref={targetRef}>
         <Title m="5rem 0 2rem" ta="center" fz="2rem">
           💿 궁금한 점이 있다면 의견을 남겨주세요.
@@ -145,7 +145,7 @@ const Comments = ({ postAuthor }) => {
           </Button>
         </Flex>
       </Container>
-      <Divider mb="5rem" variant="dashed" />
+      {filteredComments.length > 0 && <Divider mb="4rem" variant="dashed" />}
       <CommentList>
         {filteredComments?.map(comment => (
           <Comment

--- a/client/src/components/community/PostContent.jsx
+++ b/client/src/components/community/PostContent.jsx
@@ -75,7 +75,9 @@ const PostContent = ({ post }) => {
             </Flex>
           </Flex>
         </AuthorProfile>
-        <Content>{content}</Content>
+        <Content>
+          <div dangerouslySetInnerHTML={{ __html: content }} />
+        </Content>
       </PostSection>
     </>
   );

--- a/client/src/components/community/PostItem.jsx
+++ b/client/src/components/community/PostItem.jsx
@@ -6,6 +6,7 @@ import { COMMUNITY_POST_PATH } from '../../routes/routePaths';
 import formattedDate from '../../utils/formattedDate';
 import { ProfileAvatar } from '../common';
 import { AppleRecommendIcon, CheckedCircleIcon } from '.';
+import { category as CATEGORY } from '../../constants/category';
 
 const Post = styled(List.Item)`
   border: 1px solid var(--opacity-border-color);
@@ -45,6 +46,8 @@ const PostDescription = styled(Group)`
 const PostItem = ({ post }) => {
   const { id, title, createAt, category, completed, avatarId, certified, commentsLength, productType } = post;
 
+  const conditionalColor = category === CATEGORY.iphone ? 'red' : category === CATEGORY.mac ? 'green' : 'blue';
+
   return (
     <Post key={id} fz="15px" bg="var(--opacity-bg-color)">
       <PostLink to={`${COMMUNITY_POST_PATH}/${id}`}>
@@ -64,18 +67,14 @@ const PostItem = ({ post }) => {
           </PostDescription>
           <Flex ml="auto" direction="column" justify="space-between" align="flex-end">
             <Flex gap="8px" mt="4px">
-              <Badge
-                size="md"
-                variant="outline"
-                color={category === 'iPhone' ? 'red' : category === 'mac' ? 'green' : 'blue'}>
+              <Badge size="md" variant="outline" color={conditionalColor}>
                 {category}
               </Badge>
-              <Badge
-                size="md"
-                variant="filled"
-                color={category === 'iPhone' ? 'red' : category === 'mac' ? 'green' : 'blue'}>
-                {productType}
-              </Badge>
+              {productType && (
+                <Badge size="md" variant="filled" color={conditionalColor}>
+                  {productType}
+                </Badge>
+              )}
             </Flex>
             <Flex gap="4px" align="center" pr="0.8rem" fz="15px" c="var(--font-color)">
               <Text>답글</Text>

--- a/client/src/components/community/index.js
+++ b/client/src/components/community/index.js
@@ -1,5 +1,5 @@
 export { default as CommunityHeader } from './CommunityHeader';
-export { default as CommunityMain } from './CommunityMain';
+export { default as CommunityMain } from '../../pages/CommunityMain';
 export { default as SideFilter } from './SideFilter';
 export { default as CommunityMyPosts } from './CommunityMyPosts';
 export { default as AutoComplete } from './AutoComplete';

--- a/client/src/constants/categoryList.js
+++ b/client/src/constants/categoryList.js
@@ -1,7 +1,9 @@
+import { category as CATEGORY } from './category';
+
 const categoryList = [
-  { imgPath: '/community/iphone/iphone-family.png', category: 'iPhone' },
-  { imgPath: '/community/mac/mbp-notebooks.png', category: 'Mac' },
-  { imgPath: '/community/ipad/ipad-family.png', category: 'iPad' },
+  { imgPath: '/community/iphone/iphone-family.png', category: CATEGORY.iphone },
+  { imgPath: '/community/mac/mbp-notebooks.png', category: CATEGORY.mac },
+  { imgPath: '/community/ipad/ipad-family.png', category: CATEGORY.ipad },
 ];
 
 export default categoryList;

--- a/client/src/hooks/useGoBack.js
+++ b/client/src/hooks/useGoBack.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const useGoBack = () => {
+  const navigate = useNavigate();
+  const goBack = React.useCallback(() => {
+    navigate(-1);
+  }, [navigate]);
+  return goBack;
+};
+
+export default useGoBack;

--- a/client/src/pages/CommunityMain.jsx
+++ b/client/src/pages/CommunityMain.jsx
@@ -6,11 +6,11 @@ import { IoFilterCircleOutline } from 'react-icons/io5';
 import { HiOutlineTrophy } from 'react-icons/hi2';
 import { Container, Divider, Flex, Group, Image, List, Text, Title } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
-import { InfoCard } from '../common';
-import { AutoComplete, RuleModal, QuestionModal, FilterContentModal } from '.';
-import { getSearchedPosts } from '../../api/posts';
-import categoryList from '../../constants/categoryList';
-import { COMMUNITY_PATH } from '../../routes/routePaths';
+import { InfoCard } from '../components/common';
+import { AutoComplete, RuleModal, QuestionModal, FilterContentModal } from '../components/community';
+import { getSearchedPosts } from '../api/posts';
+import categoryList from '../constants/categoryList';
+import { COMMUNITY_PATH } from '../routes/routePaths';
 
 const Wrapper = styled(Container)`
   min-width: 1024px;

--- a/client/src/pages/NotFound.jsx
+++ b/client/src/pages/NotFound.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { Button, Container, Flex, Text } from '@mantine/core';
+import { FiArrowLeft } from 'react-icons/fi';
+import useGoBack from '../hooks/useGoBack';
+
+const Wrapper = styled(Container)`
+  min-width: 1024px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  margin-top: 1rem;
+  height: 100vh;
+  font-size: 0.75rem;
+  color: var(--font-color);
+`;
+
+const NotFound = () => {
+  const goBack = useGoBack();
+
+  return (
+    <Wrapper>
+      <Flex direction="column" align="center">
+        <Flex align="center" mt="8rem" mb="2rem"></Flex>
+        <Text mb="3rem" fz="1.5rem" fw="600" ta="center" c="var(--font-color)">
+          요청하신 페이지를 찾을 수 없습니다. <br />
+          입력하신 주소가 정확한 지 다시 한 번 확인해 주세요.
+        </Text>
+        <Button onClick={goBack} w={240} size="md" radius="xl" leftIcon={<FiArrowLeft size="21" />}>
+          이전 페이지로 돌아가기
+        </Button>
+      </Flex>
+    </Wrapper>
+  );
+};
+
+export default NotFound;

--- a/client/src/pages/index.js
+++ b/client/src/pages/index.js
@@ -1,6 +1,7 @@
 export { default as SignIn } from './SignIn';
 export { default as SignUp } from './SignUp';
 export { default as Community } from './Community';
+export { default as CommunityMain } from './CommunityMain';
 export { default as CommunityMe } from './CommunityMe';
 export { default as Profile } from './Profile';
 export { default as ProfileEdit } from './ProfileEdit';
@@ -8,3 +9,4 @@ export { default as RegisterProduct } from './RegisterProduct';
 export { default as CommunityPost } from './CommunityPost';
 export { default as Question } from './Question';
 export { default as Rank } from './Rank';
+export { default as NotFound } from './NotFound';

--- a/server/mock-data/users.js
+++ b/server/mock-data/users.js
@@ -61,7 +61,7 @@ let users = [
 		products: [],
 		point: 140,
 		level: 2,
-		avatarId: null,
+		avatarId: 'avatar-19',
 		aboutMe: '',
 	},
 	{


### PR DESCRIPTION
### Change
---
- `CommunityMain` 페이지 디렉토리로 이동 및 Import 변경
- `useGoBack` hook 추가
- `NotFound`페이지 추가
- 질문하기로 글 작성 후 화면에 보여질 text 렌더링 올바르게 되도록 변경
- `PostItem` 컴포넌트 내 Badge UI 제품 선택 누락 시 보이지 않는 UI 문제 변경
- `comments` 배열의 길이에 따른 `Divider` 컴포넌트 조건부 렌더링
- `AutoComplete` `search` 관련 api 요청 `avatarId` 오류 관련 mock-data 수정