### PR TITLE
[FEAT] : AutoComplete 관련 Firebase 함수 및 util 함수 구현

### DIFF
--- a/client/firebase/comments.js
+++ b/client/firebase/comments.js
@@ -13,8 +13,10 @@ import {
   arrayUnion,
 } from 'firebase/firestore';
 import app from './app';
+import { specifySnapshotIntoData, formattedCreateAt, formattedUpdateAt } from './utils';
 
 const db = getFirestore(app);
+const COLLECTION = 'comments';
 
 const getComments = async ({ postId }) => {
   const commentRef = collection(db, 'comments');
@@ -24,35 +26,38 @@ const getComments = async ({ postId }) => {
 
   return commentSnapshot.docs.map(comment => {
     const commentData = comment.data();
-    const createAt = commentData.createAt.toDate();
-    const updateAt = commentData.updateAt.toDate();
 
-    return { ...commentData, createAt: new Date(createAt), updateAt: new Date(updateAt), id: comment.id };
+    return {
+      ...commentData,
+      createAt: new Date(formattedCreateAt(commentData)),
+      updateAt: new Date(formattedUpdateAt(commentData)),
+      id: comment.id,
+    };
   });
 };
 
 const createComment = async commentInfo => {
-  const commentRef = addDoc(collection(db, 'comments'), { commentInfo, createAt: serverTimestamp() });
+  const commentRef = addDoc(collection(db, COLLECTION), { commentInfo, createAt: serverTimestamp() });
 
   return commentRef.id;
 };
 
 const editComment = async ({ id, content }) => {
-  await updateDoc(doc(db, 'comments', id), { content, updateAt: serverTimestamp() });
+  await updateDoc(doc(db, COLLECTION, id), { content, updateAt: serverTimestamp() });
 };
 
 const toggleAdopted = async ({ id, adopted }) => {
-  await updateDoc(doc(db, 'comments', id), { adopted });
+  await updateDoc(doc(db, COLLECTION, id), { adopted });
 };
 
 const toggleCommentLike = async ({ id, checked, userId }) => {
-  await updateDoc(doc(db, 'comments', id), {
+  await updateDoc(doc(db, COLLECTION, id), {
     like: checked ? arrayRemove(userId) : arrayUnion(userId),
   });
 };
 
 const removeComment = async ({ id }) => {
-  await deleteDoc(doc(db, 'comments', id));
+  await deleteDoc(doc(db, COLLECTION, id));
 };
 
 export { getComments, createComment, editComment, removeComment, toggleAdopted, toggleCommentLike };

--- a/client/firebase/posts.js
+++ b/client/firebase/posts.js
@@ -1,56 +1,82 @@
 import {
-  addDoc,
+  getFirestore,
   collection,
+  doc,
+  or,
   getDocs,
   getDoc,
-  getFirestore,
+  addDoc,
   updateDoc,
-  doc,
   deleteDoc,
   serverTimestamp,
   arrayRemove,
   arrayUnion,
+  query,
+  where,
 } from 'firebase/firestore';
 import app from './app';
+import { specifySnapshotIntoData, formattedCreateAt, formattedUpdateAt } from './utils';
 
 const db = getFirestore(app);
+const COLLECTION = 'posts';
 
 const getPosts = async () => {
-  const postSnapshot = await getDocs(collection(db, 'posts'));
+  const postSnapshot = await getDocs(collection(db, COLLECTION));
 
-  return postSnapshot.docs.map(post => {
-    const postData = post.data();
-    const createAt = postData.createAt.toDate();
-    const updateAt = postData?.updateAt?.toDate();
-
-    return { ...postData, createAt: new Date(createAt), updateAt: new Date(updateAt), id: post.id };
-  });
+  return specifySnapshotIntoData(postSnapshot);
 };
+
+// select된 값을 keyword로 받는 작업도 필요
+const getSearchedPosts = async ({ keyword = '', category = '', subCategory = '' }) => {
+  const postsRef = collection(db, COLLECTION);
+  const postSnapshot = await getDocs(collection(db, COLLECTION));
+
+  const q = query(postsRef, or(where('category', '==', category), where('subCategory', '==', subCategory)));
+  const filteredPostSnapshot = await getDocs(q);
+
+  const searchedPosts = specifySnapshotIntoData(category === '' ? postSnapshot : filteredPostSnapshot)
+    .filter(({ title }) => new RegExp(keyword, 'i').test(title))
+    .slice(0, 5);
+
+  return searchedPosts;
+};
+
+// 내가 작성한 글 목록 :auth 정보 필요
+const getMyPosts = async () => {};
 
 const getPost = async ({ postId }) => {
-  const postSnapshot = await getDoc(doc(db, 'posts', postId));
+  const postSnapshot = await getDoc(doc(db, COLLECTION, postId));
+  const postData = postSnapshot.data();
 
-  return { ...postSnapshot.data(), id: postSnapshot.id };
+  return {
+    ...postData,
+    createAt: formattedCreateAt(postData),
+    updateAt: formattedUpdateAt(postData),
+    id: postSnapshot.id,
+  };
 };
 
+// 사용자 프로필 - 글 목록
+const getProfileWithPosts = async () => {};
+
 const createPost = async postInfo => {
-  const postRef = await addDoc(collection(db, 'posts'), { ...postInfo, createAt: serverTimestamp() });
+  const postRef = await addDoc(collection(db, COLLECTION), { ...postInfo, createAt: serverTimestamp() });
 
   return postRef.id;
 };
 
 const editPost = async ({ id, title, content }) => {
-  await updateDoc(doc(db, 'posts', id), { title, content, updateAt: serverTimestamp() });
+  await updateDoc(doc(db, COLLECTION, id), { title, content, updateAt: serverTimestamp() });
 };
 
 const removePost = async id => {
-  await deleteDoc(doc(db, 'posts', id));
+  await deleteDoc(doc(db, COLLECTION, id));
 };
 
 const togglePostLike = async ({ id, checked, userId }) => {
-  await updateDoc(doc(db, 'posts', id), {
+  await updateDoc(doc(db, COLLECTION, id), {
     like: checked ? arrayRemove(userId) : arrayUnion(userId),
   });
 };
 
-export { getPosts, getPost, createPost, editPost, removePost, togglePostLike };
+export { getPosts, getSearchedPosts, getPost, createPost, editPost, removePost, togglePostLike };

--- a/client/firebase/utils.js
+++ b/client/firebase/utils.js
@@ -1,0 +1,16 @@
+const specifySnapshotIntoData = snapshot =>
+  snapshot.docs.map(doc => {
+    const specifiedData = doc.data();
+
+    return {
+      ...specifiedData,
+      createAt: new Date(formattedCreateAt(specifiedData)),
+      updateAt: new Date(formattedUpdateAt(specifiedData)),
+      id: doc.id,
+    };
+  });
+
+const formattedCreateAt = data => data?.createAt.toDate();
+const formattedUpdateAt = data => data?.updateAt?.toDate();
+
+export { specifySnapshotIntoData, formattedCreateAt, formattedUpdateAt };

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -60,9 +60,9 @@ const router = createBrowserRouter([
         path: '/computer-it',
         element: <ComputerIt />,
         children: [
-          { index: true, element: <CommunityMain /> },
+          { index: true, element: <CommunityMain category="computer-it" /> },
           {
-            path: ':sub-category',
+            path: ':subCategory',
             loader: postsByCategoryLoader(queryClient),
             element: <CommunityCategory category="computer-it" />,
           },
@@ -76,11 +76,11 @@ const router = createBrowserRouter([
         path: '/game',
         element: <Game />,
         children: [
-          { index: true, element: <CommunityMain /> },
+          { index: true, element: <CommunityMain category="game" /> },
           {
-            path: ':sub-category',
+            path: ':subCategory',
             loader: postsByCategoryLoader(queryClient),
-            element: <CommunityCategory />,
+            element: <CommunityCategory category="game" />,
           },
           {
             path: 'list/popular',

--- a/client/src/components/community/CommunityCategorySection.jsx
+++ b/client/src/components/community/CommunityCategorySection.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { useParams } from 'react-router-dom';
 import { Flex, Title, Image } from '@mantine/core';
-import { getSearchedPosts } from '../../api/posts';
 import { CATEGORY } from '../../constants/category';
 import { AutoComplete, PostSection } from '.';
 import { postsByCategoryQuery } from '../../queries';
+import { getSearchedPosts } from '../../../firebase/posts';
 
 const CategoryImage = styled(Image)`
   display: flex;
@@ -18,23 +18,23 @@ const CategoryImage = styled(Image)`
   }
 `;
 
-const CommunityCategorySection = () => {
-  const { category } = useParams();
+const CommunityCategorySection = ({ category }) => {
+  const { subCategory } = useParams();
 
   return (
     <>
       <Flex gap="0.5rem" mt="4rem">
-        <CategoryImage
-          src={`/community/${category}/${category}-category.png`}
-          alt={`${category}-category-img`}
-          category={category}
-        />
+        {/* <CategoryImage
+          src={`/community/${subCategory}/${subCategory}-category.png`}
+          alt={`${subCategory}-category-img`}
+          category={subCategory}
+        /> */}
         <Flex direction="column" justify="center">
-          <Title mb="3rem">{CATEGORY[category]}</Title>
-          <AutoComplete width={720} queryFn={getSearchedPosts} category={category} />
+          {/* <Title mb="3rem">{CATEGORY[subCategory]}</Title> */}
+          <AutoComplete width={720} queryFn={getSearchedPosts} category={category} subCategory={subCategory} />
         </Flex>
       </Flex>
-      <PostSection queryFn={postsByCategoryQuery(category)} />
+      <PostSection queryFn={postsByCategoryQuery(subCategory)} />
     </>
   );
 };

--- a/client/src/components/community/autoComplete/AutoComplete.jsx
+++ b/client/src/components/community/autoComplete/AutoComplete.jsx
@@ -41,13 +41,13 @@ const CommunityAutoComplete = styled(Autocomplete)`
 
 const LIMIT_OF_POSTS = 10;
 
-const AutoComplete = ({ width = 620, queryFn, category = '' }) => {
+const AutoComplete = ({ width = 620, queryFn, category = '', subCategory = '' }) => {
   const [value, setValue] = React.useState('');
   const [debounced] = useDebouncedValue(value, 500);
 
   const navigate = useNavigate();
 
-  const posts = useAutoCompleteQuery({ inputValue: debounced, queryFn, category });
+  const posts = useAutoCompleteQuery({ inputValue: debounced, queryFn, category, subCategory });
 
   return (
     <CommunityAutoComplete

--- a/client/src/hooks/queries/useAutoCompleteQuery.js
+++ b/client/src/hooks/queries/useAutoCompleteQuery.js
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
 import React from 'react';
+import { useQuery } from '@tanstack/react-query';
 
 const staleTime = 3000;
 
@@ -9,17 +9,17 @@ const staleTime = 3000;
  * queryFn: () => promise
  * }} props
  */
-const useAutoCompleteQuery = ({ inputValue, category, queryFn }) => {
+const useAutoCompleteQuery = ({ inputValue, queryFn, category, subCategory }) => {
   const [value, setValue] = React.useState([]);
 
   const { data: posts, isFetched } = useQuery({
-    queryKey: ['posts', inputValue, category],
+    queryKey: ['posts', inputValue, category, subCategory],
     queryFn: async () => {
-      const { data: posts } = await queryFn({ keyword: inputValue, category });
-      return posts;
+      const data = await queryFn({ keyword: inputValue, category, subCategory });
+      return data;
     },
     staleTime,
-    select: data => data.posts.map(post => ({ ...post, value: post.id })),
+    select: posts => posts.map(post => ({ ...post, value: post.id })),
   });
 
   React.useEffect(() => {

--- a/client/src/pages/CommunityCategory.jsx
+++ b/client/src/pages/CommunityCategory.jsx
@@ -14,9 +14,9 @@ const Wrapper = styled(Container)`
   color: var(--font-color);
 `;
 
-const CommunityCategory = () => (
+const CommunityCategory = ({ category }) => (
   <Wrapper>
-    <CommunityCategorySection />
+    <CommunityCategorySection category={category} />
   </Wrapper>
 );
 

--- a/client/src/pages/CommunityMain.jsx
+++ b/client/src/pages/CommunityMain.jsx
@@ -3,9 +3,9 @@ import styled from '@emotion/styled';
 import { Link } from 'react-router-dom';
 import { Container, Image, List, Text, Title } from '@mantine/core';
 import { AutoComplete, Tutorials } from '../components';
-import { getSearchedPosts } from '../api/posts';
 import categoryList from '../constants/categoryList';
 import { COMPUTER_IT_PATH } from '../routes/routePaths';
+import { getSearchedPosts } from '../../firebase/posts';
 
 const Wrapper = styled(Container)`
   min-width: 1024px;
@@ -65,7 +65,7 @@ const CategoryDescription = styled.p`
   text-decoration: none;
 `;
 
-const CommunityMain = () => (
+const CommunityMain = ({ category }) => (
   <Wrapper>
     <Description>
       <Title size="52px" mt="24px" mb="40px">
@@ -74,7 +74,7 @@ const CommunityMain = () => (
       <Text fz="26px" mb="40px">
         전 세계 FineApple 고객들과 소통해 보세요 🚀
       </Text>
-      <AutoComplete width={720} queryFn={getSearchedPosts} />
+      <AutoComplete width={720} queryFn={getSearchedPosts} category={category} />
     </Description>
 
     <Image src="/community/community-main.png" alt="community" pt="6rem" pb="3rem" />

--- a/client/src/pages/CommunityPostDetail.jsx
+++ b/client/src/pages/CommunityPostDetail.jsx
@@ -24,6 +24,7 @@ const Wrapper = styled(Container)`
   color: var(--font-color);
 `;
 
+// [] todo: postInfo의 author, certified auth 연결 후 임의 데이터 수정 필요
 const CommunityPostDetail = () => {
   const { postId } = useParams();
   const { data: post } = useQuery(postDetailQuery(postId));
@@ -41,10 +42,7 @@ const CommunityPostDetail = () => {
       <PostContent post={post} />
       <Divider variant="dashed" />
       <React.Suspense fallback={<CommentLoader />}>
-        <CommentSection
-          postInfo={{ id: postId, author: post.author, certified: post.certified }}
-          mutateFns={mutateFns}
-        />
+        <CommentSection postInfo={{ id: postId, author: 'cool jp', certified: true }} mutateFns={mutateFns} />
       </React.Suspense>
     </Wrapper>
   );


### PR DESCRIPTION
### Change
---
- Post 상세 페이지 임시 에러 제거를 위한 mock-data 업로드
  - `postInfo`의 author, certified mock-data 업로드

- `App.jsx` subCategory path 수정 및 대분류 category prop 전달 추가 
- `AutoComplete` 관련 Firebase 비동기 요청 함수 및 util 함수 구현
- `AutoComplete` 관련 컴포넌트 및 react-query 비동기 요청 함수 수정

### Discuss
---
- 상단 Nav 너비 조정
- user auth 관련 firebase 코드 필요
